### PR TITLE
fixes an indexing error in BuildLoop

### DIFF
--- a/Geometry.cs
+++ b/Geometry.cs
@@ -432,9 +432,9 @@ namespace Weland {
 	    if (depth >= 8) {
 		return false;
 	    } else if (current == target) {
-		int other_index = Lines[list[list.Count - 1]].EndpointIndexes[0];
+		int other_index = Lines[list[0]].EndpointIndexes[0];
 		if (other_index == current)
-		    other_index = Lines[list[list.Count - 1]].EndpointIndexes[1];
+		    other_index = Lines[list[0]].EndpointIndexes[1];
 		double cross = Cross(Diff(Endpoints[prev], Endpoints[current]), Diff(Endpoints[other_index], Endpoints[current]));
 		if (cross >= 0.0) {
 		    return true;


### PR DESCRIPTION
BuildLoop tries to build closed line loops by walking along the graph of lines, trying to find the tightest-wrapping (in some direction, ccw or cw, I forget) lines it can find, hoping that they end up closing into a loop. If it actually manages to find a closed loop this way, there is one stray test at the end where it checks that the last line added and the first line added still form a convex polygon. Before this fix, "first line" accidentally referred to "previous line", which was true by fiat.

I am a little surprised I didn't have to change the order of the arguments to Cross to get it to work, but it seems to work in all previous good cases and fix the one bad one provided by effigy. So: OK!
