### PR TITLE
Fix for Phoenix shapes.

### DIFF
--- a/Assembly.cs
+++ b/Assembly.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-[assembly:AssemblyVersionAttribute ("1.4.3.0")]
+[assembly:AssemblyVersionAttribute ("1.4.4.0")]
 [assembly:AssemblyTitleAttribute ("Weland")]
 [assembly:AssemblyDescriptionAttribute ("Marathon Map Editor")]
-[assembly:AssemblyCopyrightAttribute ("\u2117 2009-2015 Gregory Smith (GPL)")]
+[assembly:AssemblyCopyrightAttribute ("\u2117 2009-2018 Gregory Smith (GPL)")]


### PR DESCRIPTION
Getting walls shapes from a collection will now use the passed bitmap index as-is if it is beyond the range of the lowLevelShapeCount (frames).