### PR TITLE
Disallow Saving With Invalid Platform Triggers

### DIFF
--- a/gtk-sharp/MapWindow.cs
+++ b/gtk-sharp/MapWindow.cs
@@ -978,7 +978,7 @@ namespace Weland {
 	    d.CurrentName = Level.Name + ".sceA";
 	    d.DoOverwriteConfirmation = true;
 	    try {
-                Level.Validate();
+		Level.Validate();
 		if (d.Run() == (int) ResponseType.Accept) {
 		    mapfile = new MapFile();
 		    Level.AssurePlayerStart();
@@ -1015,7 +1015,7 @@ namespace Weland {
 	    } else {
 		bool success = false;
 		try {
-                    Level.Validate();
+		    Level.Validate();
 		    Level.AssurePlayerStart();
 		    Redraw();
 		    mapfile.Directory[0] = Level.Save();

--- a/gtk-sharp/MapWindow.cs
+++ b/gtk-sharp/MapWindow.cs
@@ -978,6 +978,7 @@ namespace Weland {
 	    d.CurrentName = Level.Name + ".sceA";
 	    d.DoOverwriteConfirmation = true;
 	    try {
+                Level.Validate();
 		if (d.Run() == (int) ResponseType.Accept) {
 		    mapfile = new MapFile();
 		    Level.AssurePlayerStart();
@@ -1014,6 +1015,7 @@ namespace Weland {
 	    } else {
 		bool success = false;
 		try {
+                    Level.Validate();
 		    Level.AssurePlayerStart();
 		    Redraw();
 		    mapfile.Directory[0] = Level.Save();

--- a/level/Level.cs
+++ b/level/Level.cs
@@ -347,6 +347,29 @@ namespace Weland {
 	    }	    
 	}
 
+        void ValidatePlatformTriggers() {
+	    for (int i = 0; i < Polygons.Count; ++i) {
+		    Polygon polygon = Polygons[i];
+		    if (polygon.Type == PolygonType.PlatformOnTrigger || polygon.Type == PolygonType.PlatformOffTrigger) {
+                        bool found = false;
+	                foreach (Platform platform in Platforms) {
+				if (platform.PolygonIndex == polygon.Permutation) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				string message = "Invalid map: Platform trigger at polygon " + i + " does not have a valid platform assigned.";
+				throw new Wadfile.BadMapException(message);
+			}
+		    }
+            }
+        }
+
+	public void Validate() {
+		ValidatePlatformTriggers();
+        }
+
 	public Wadfile.DirectoryEntry Save() {
 	    Wadfile.DirectoryEntry wad = new Wadfile.DirectoryEntry();
 	    wad.Chunks = Chunks;

--- a/level/Level.cs
+++ b/level/Level.cs
@@ -349,25 +349,25 @@ namespace Weland {
 
         void ValidatePlatformTriggers() {
 	    for (int i = 0; i < Polygons.Count; ++i) {
-		    Polygon polygon = Polygons[i];
-		    if (polygon.Type == PolygonType.PlatformOnTrigger || polygon.Type == PolygonType.PlatformOffTrigger) {
-                        bool found = false;
-	                foreach (Platform platform in Platforms) {
-				if (platform.PolygonIndex == polygon.Permutation) {
-					found = true;
-					break;
-				}
-			}
-			if (!found) {
-				string message = "Invalid map: Platform trigger at polygon " + i + " does not have a valid platform assigned.";
-				throw new Wadfile.BadMapException(message);
-			}
+	        Polygon polygon = Polygons[i];
+		if (polygon.Type == PolygonType.PlatformOnTrigger || polygon.Type == PolygonType.PlatformOffTrigger) {
+                    bool found = false;
+	            foreach (Platform platform in Platforms) {
+	                if (platform.PolygonIndex == polygon.Permutation) {
+		            found = true;
+	                    break;
+	                }
 		    }
-            }
-        }
+	            if (!found) {
+	                string message = "Invalid map: Platform trigger at polygon " + i + " does not have a valid platform assigned.";
+	                throw new Wadfile.BadMapException(message);
+                    }
+	        }
+	    }
+	}
 
 	public void Validate() {
-		ValidatePlatformTriggers();
+	    ValidatePlatformTriggers();
         }
 
 	public Wadfile.DirectoryEntry Save() {

--- a/level/Level.cs
+++ b/level/Level.cs
@@ -368,7 +368,7 @@ namespace Weland {
 
 	public void Validate() {
 	    ValidatePlatformTriggers();
-        }
+	}
 
 	public Wadfile.DirectoryEntry Save() {
 	    Wadfile.DirectoryEntry wad = new Wadfile.DirectoryEntry();

--- a/level/Level.cs
+++ b/level/Level.cs
@@ -347,7 +347,7 @@ namespace Weland {
 	    }	    
 	}
 
-        void ValidatePlatformTriggers() {
+	void ValidatePlatformTriggers() {
 	    for (int i = 0; i < Polygons.Count; ++i) {
 	        Polygon polygon = Polygons[i];
 		if (polygon.Type == PolygonType.PlatformOnTrigger || polygon.Type == PolygonType.PlatformOffTrigger) {


### PR DESCRIPTION
Closes #12 

Create a dialogue notifying the user when they try to save when a platform on or off trigger has no existing platform assigned.