### PR TITLE
Use 65536 instead of 65535 for FIXED_ONE, and correctly round when converting from float to fixed

### DIFF
--- a/BinaryReaderBE.cs
+++ b/BinaryReaderBE.cs
@@ -40,7 +40,7 @@ public class BinaryReaderBE : BinaryReader
 
 	public double ReadFixed() {
 	    int i = ReadInt32();
-	    return (double) i / ushort.MaxValue;
+	    return (double) i / 65536.0;
 	}
 
 	public string ReadMacString(int length)

--- a/BinaryWriterBE.cs
+++ b/BinaryWriterBE.cs
@@ -32,7 +32,7 @@ public class BinaryWriterBE : BinaryWriter
     }
     
     public void WriteFixed(double value) {
-	int i = (int) Math.Floor(value * ushort.MaxValue);
+	int i = (int) Math.Floor(value * 65536.0 + 0.5);
 	Write(i);
     }
 

--- a/BinaryWriterBE.cs
+++ b/BinaryWriterBE.cs
@@ -32,7 +32,7 @@ public class BinaryWriterBE : BinaryWriter
     }
     
     public void WriteFixed(double value) {
-	int i = (int) Math.Floor(value * 65536.0 + 0.5);
+	int i = (int) Math.Truncate(value * 65536.0);
 	Write(i);
     }
 


### PR DESCRIPTION
(The correct[citation needed] rounding mode for a float-to-fixed conversion is ~~Round Nearest Ties Toward Zero~~ Round Nearest Ties Away.)

Edit: Turns out Forge uses floor, so we should too.