### PR TITLE
Remove BmpSharp nuget for Gtk3 and fix the bitmap messed up palette on mac

### DIFF
--- a/Weland.csproj
+++ b/Weland.csproj
@@ -217,8 +217,8 @@
 
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.24.24.95" />
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
   </ItemGroup>
 

--- a/Weland.csproj
+++ b/Weland.csproj
@@ -216,7 +216,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BmpSharp" Version="0.2.0" />
     <PackageReference Include="GtkSharp" Version="3.24.24.95" />
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />


### PR DESCRIPTION
This is to remove the BmpSharp nuget with very few support and apparently not working correctly on mac at least.
SkiaSharp provides an assembly with some extensions (https://learn.microsoft.com/en-us/dotnet/api/skiasharp.views.gtk.gtkextensions?view=skiasharp-views-2.88) and one is to deal with Gdk pixbuf.

But this brings a lot of assembly dependencies and it's not easily usable since those assemblies depend on a specific Gdk version (older than the last one used in this branch).  So I juse took the code from that extension and use it directly there instead.
That should fix the problem on mac, and we can get rid of BmpSharp nuget.

I also upgraded skia libs, since they discovered a security issue in the current version.  https://github.com/advisories/GHSA-j7hp-h8jx-5ppr
